### PR TITLE
add malloc check

### DIFF
--- a/src/bsd/tunemu.c
+++ b/src/bsd/tunemu.c
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include <ctype.h>
 #include <fcntl.h>
+#include <err.h>
 
 #define PPPPROTO_CTL 1
 
@@ -259,8 +260,8 @@ static void allocate_data_buffer(int size)
 	if (data_buffer_length < size)
 	{
 		free(data_buffer);
-		data_buffer_length = size;
-		data_buffer = malloc(data_buffer_length);
+		if ((data_buffer = malloc(size)) == NULL)
+			err(1, NULL);
 	}
 }
 


### PR DESCRIPTION
malloc can fail. check for errors or use xmalloc.
since this is bsd only, as seen in Makefile.am, it is safe to use err(3) and err.h.
