### PR TITLE
fixed usage of size_t for time_t (now using difftime()), in order to …

### DIFF
--- a/src/protocol_auth.c
+++ b/src/protocol_auth.c
@@ -747,8 +747,8 @@ static void send_everything(connection_t *c) {
 
 	for splay_each(node_t, n, node_tree) {
 			if ((!n->status.reachable) && ((now.tv_sec - n->last_state_change) >= keylifetime*2)) {
-				logger(DEBUG_CONNECTIONS, LOG_INFO, "Not forwarding informations about %s to %s (%zu / %d)", n->name,
-							 c->name, now.tv_sec - n->last_state_change, keylifetime);
+				logger(DEBUG_CONNECTIONS, LOG_INFO, "Not forwarding informations about %s to %s (%lf / %d)", n->name,
+							 c->name, difftime(now.tv_sec, n->last_state_change), keylifetime);
 				continue;
 			}
 

--- a/src/protocol_misc.c
+++ b/src/protocol_misc.c
@@ -100,7 +100,7 @@ bool send_ping(connection_t *c) {
 	c->status.pinged = true;
 	c->last_ping_time = now;
 
-	return send_request(c, "%d %zu %ld", PING, c->last_ping_time.tv_sec, c->last_ping_time.tv_usec);
+	return send_request(c, "%d %lf %ld", PING, difftime(c->last_ping_time.tv_sec,0), c->last_ping_time.tv_usec);
 }
 
 bool ping_h(connection_t *c, const char *request) {

--- a/src/protocol_misc.c
+++ b/src/protocol_misc.c
@@ -100,7 +100,7 @@ bool send_ping(connection_t *c) {
 	c->status.pinged = true;
 	c->last_ping_time = now;
 
-	return send_request(c, "%d %lf %ld", PING, difftime(c->last_ping_time.tv_sec,0), c->last_ping_time.tv_usec);
+	return send_request(c, "%d %zu %ld", PING, c->last_ping_time.tv_sec, c->last_ping_time.tv_usec);
 }
 
 bool ping_h(connection_t *c, const char *request) {

--- a/src/protocol_misc.c
+++ b/src/protocol_misc.c
@@ -100,7 +100,7 @@ bool send_ping(connection_t *c) {
 	c->status.pinged = true;
 	c->last_ping_time = now;
 
-	return send_request(c, "%d %zu %ld", PING, c->last_ping_time.tv_sec, c->last_ping_time.tv_usec);
+	return send_request(c, "%d %zu %ld", PING, (size_t)c->last_ping_time.tv_sec, c->last_ping_time.tv_usec);
 }
 
 bool ping_h(connection_t *c, const char *request) {

--- a/src/protocol_subnet.c
+++ b/src/protocol_subnet.c
@@ -120,7 +120,7 @@ bool add_subnet_h(connection_t *c, const char *request) {
 		logger(DEBUG_ALWAYS, LOG_WARNING, "Ignoring unauthorized %s from %s (%s): %s",
 				"ADD_SUBNET", c->name, c->hostname, subnetstr);
 		if ((!owner->status.reachable) && ((now.tv_sec - owner->last_state_change) >= keylifetime*2)) {
-				logger(DEBUG_CONNECTIONS, LOG_INFO, "Not forwarding informations about %s to ALL (%zu / %d)", owner->name, now.tv_sec - owner->last_state_change, keylifetime);
+				logger(DEBUG_CONNECTIONS, LOG_INFO, "Not forwarding informations about %s to ALL (%lf / %d)", owner->name, difftime(now.tv_sec, owner->last_state_change), keylifetime);
 		} else {
 			forward_request(c, request);
 		}


### PR DESCRIPTION
…make it compile on armhf architectures

This allows us to do not care about size_t != time_t errors anymore.
Source:
http://stackoverflow.com/a/22175846/3458484

Tested on:
GNU/Linux 4.4.0-59-generic     x86_64
GNU/Linux 4.4.21-v7+              armv7l

works like a charm.
